### PR TITLE
Problems with standard API Gateway response

### DIFF
--- a/handlers/_not-found.yml
+++ b/handlers/_not-found.yml
@@ -1,0 +1,9 @@
+  # Config for Not Found Endpoints
+  notFound:
+    handler: modules/redirects.notFound
+    timeout: 30
+    events:
+      - http:
+          path: /{proxy+} # catch any path not specified elsewhere
+          method: any
+          corst: true

--- a/modules/redirects.js
+++ b/modules/redirects.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const response = require('../shared/lib/response');
+
+module.exports.notFound = (event, context, callback) => {
+  return response.json(callback, null, response);
+};


### PR DESCRIPTION
Most of the time, especially when we have an authorizer, the default response is 403 and/or _missing token_ for routes that are not described in the API.

We should explicit overwrite to return 404.